### PR TITLE
chore(.pre-commit-config.yaml): update typos to v1.28.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.26.0
+    rev: v1.28.4
     hooks:
       - id: typos


### PR DESCRIPTION
- Update the `typos` hook in the `.pre-commit-config.yaml` file to use version `v1.28.4` of the `typos` repository.