### PR TITLE
chore(.pre-commit-config.yaml): update typos hook to v1.29.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.28.4
+    rev: v1.29.3
     hooks:
       - id: typos


### PR DESCRIPTION
- Update the `typos` hook in the `.pre-commit-config.yaml` file to version `v1.29.3` from `v1.28.4`.